### PR TITLE
Updates to Autocomplete Triggering

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
         "curly": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",
-        "semi": "off"
+        "semi": "off",
+        "quotes": [2, "single", "avoid-escape"]
     },
     "ignorePatterns": [
         "out",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,11 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 import {
   getCompletionItem,
   getHoverPreview,
   getVariableAtPosition,
-} from "./utils";
+} from './utils';
 
 type Var = {
   name: string;
@@ -20,13 +20,13 @@ type Config = {
 };
 
 const defaultConfig: Config = {
-  include: "**/*.globals.{ts,js,tsx,jsx}",
+  include: '**/*.globals.{ts,js,tsx,jsx}',
   exclude: undefined,
   autoCompleteOn: [
-    "javascript",
-    "typescript",
-    "javascriptreact",
-    "typescriptreact",
+    'javascript',
+    'typescript',
+    'javascriptreact',
+    'typescriptreact',
   ],
 };
 
@@ -34,17 +34,17 @@ export async function activate(context: vscode.ExtensionContext) {
   console.log(
     'Congratulations, your extension "styled-global-variable-autocomplete" is now active!'
   );
-  const config = vscode.workspace.getConfiguration("variablesAutocomplete");
-  const includeFilesGlob = config.get<Config["include"]>(
-    "include",
+  const config = vscode.workspace.getConfiguration('variablesAutocomplete');
+  const includeFilesGlob = config.get<Config['include']>(
+    'include',
     defaultConfig.include
   );
-  const excludeFilesGlob = config.get<Config["exclude"]>(
-    "exclude",
+  const excludeFilesGlob = config.get<Config['exclude']>(
+    'exclude',
     defaultConfig.exclude
   );
-  const autoCompleteOn = config.get<Config["autoCompleteOn"]>(
-    "autoCompleteOn",
+  const autoCompleteOn = config.get<Config['autoCompleteOn']>(
+    'autoCompleteOn',
     defaultConfig.autoCompleteOn
   );
 
@@ -69,13 +69,13 @@ export async function activate(context: vscode.ExtensionContext) {
       .split(/\r?\n/)
       .map((line, i) => {
         const lineTrim = line.trim();
-        const isVariable = line.trim().startsWith("--");
+        const isVariable = line.trim().startsWith('--');
         if (!isVariable) {
           return;
         }
 
-        const [name, rawValue] = lineTrim.split(":");
-        const value = rawValue.trim().replace(";", "");
+        const [name, rawValue] = lineTrim.split(':');
+        const value = rawValue.trim().replace(';', '');
 
         // Prevent duplicate or empty variables
         if (!value || vars.has(name)) {
@@ -108,8 +108,8 @@ export async function activate(context: vscode.ExtensionContext) {
       ) {
         const range = document.getWordRangeAtPosition(position, /\S+/);
         const currentLine = document.lineAt(position.line);
-        const isCssPropLine = currentLine.text.includes("css={{");
-        const isVarPresent = currentLine.text.includes("var(");
+        const isCssPropLine = currentLine.text.includes('css={{');
+        const isVarPresent = currentLine.text.includes('var(');
 
         const variables = finalItems.map(({ name, value }) =>
           getCompletionItem({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,106 +1,171 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode';
-import { getCompletionItem, getHoverPreview, getVariableAtPosition } from './utils';
+import * as vscode from "vscode";
+import {
+  getCompletionItem,
+  getHoverPreview,
+  getVariableAtPosition,
+} from "./utils";
 
-type Var = { name: string, value: string, uri: vscode.Uri, range: vscode.Range };
+type Var = {
+  name: string;
+  value: string;
+  uri: vscode.Uri;
+  range: vscode.Range;
+};
 type Config = {
-  include: vscode.GlobPattern
-  exclude: vscode.GlobPattern | undefined
-  autoCompleteOn: vscode.DocumentSelector
+  include: vscode.GlobPattern;
+  exclude: vscode.GlobPattern | undefined;
+  autoCompleteOn: vscode.DocumentSelector;
 };
 
-const defaultConfig: Config  = {
-  include: '**/*.globals.{ts,js,tsx,jsx}',
+const defaultConfig: Config = {
+  include: "**/*.globals.{ts,js,tsx,jsx}",
   exclude: undefined,
-  autoCompleteOn: ['javascript', 'typescript', 'javascriptreact', 'typescriptreact']
+  autoCompleteOn: [
+    "javascript",
+    "typescript",
+    "javascriptreact",
+    "typescriptreact",
+  ],
 };
 
 export async function activate(context: vscode.ExtensionContext) {
-  console.log('Congratulations, your extension "styled-global-variable-autocomplete" is now active!');
-  const config = vscode.workspace.getConfiguration('variablesAutocomplete');
-  const includeFilesGlob = config.get<Config['include']>('include', defaultConfig.include);
-  const excludeFilesGlob = config.get<Config['exclude']>('exclude', defaultConfig.exclude);
-  const autoCompleteOn = config.get<Config['autoCompleteOn']>('autoCompleteOn', defaultConfig.autoCompleteOn);
+  console.log(
+    'Congratulations, your extension "styled-global-variable-autocomplete" is now active!'
+  );
+  const config = vscode.workspace.getConfiguration("variablesAutocomplete");
+  const includeFilesGlob = config.get<Config["include"]>(
+    "include",
+    defaultConfig.include
+  );
+  const excludeFilesGlob = config.get<Config["exclude"]>(
+    "exclude",
+    defaultConfig.exclude
+  );
+  const autoCompleteOn = config.get<Config["autoCompleteOn"]>(
+    "autoCompleteOn",
+    defaultConfig.autoCompleteOn
+  );
 
   // Find all files that match configured criteria
-  const filesUri = await vscode.workspace.findFiles(includeFilesGlob, excludeFilesGlob);
+  const filesUri = await vscode.workspace.findFiles(
+    includeFilesGlob,
+    excludeFilesGlob
+  );
 
   // Read all found files
-  const filesPromises = filesUri.map(file => vscode.workspace.openTextDocument(file));
+  const filesPromises = filesUri.map((file) =>
+    vscode.workspace.openTextDocument(file)
+  );
   const documents = await Promise.all(filesPromises);
 
   // Get all variables from lines
-  const finalItems = documents.flatMap(document => {
+  const finalItems = documents.flatMap((document) => {
     const file = document.getText();
     const vars = new Map();
 
-    return file.split(/\r?\n/)
+    return file
+      .split(/\r?\n/)
       .map((line, i) => {
         const lineTrim = line.trim();
-        const isVariable = line.trim().startsWith('--');
-        if (!isVariable) { return; };
+        const isVariable = line.trim().startsWith("--");
+        if (!isVariable) {
+          return;
+        }
 
         const [name, rawValue] = lineTrim.split(":");
-        const value = rawValue.trim().replace(';', '');
+        const value = rawValue.trim().replace(";", "");
 
         // Prevent duplicate or empty variables
-        if (!value || vars.has(name)) { return; };
+        if (!value || vars.has(name)) {
+          return;
+        }
 
         vars.set(name, value);
         return {
           name,
           value,
           uri: document.uri,
-          range: new vscode.Range(new vscode.Position(i, 4), new vscode.Position(i, name.length + 4))
+          range: new vscode.Range(
+            new vscode.Position(i, 4),
+            new vscode.Position(i, name.length + 4)
+          ),
         } as Var;
       })
       .filter(Boolean) as Var[];
   });
 
   // Support autocomplete
-  const completionProvider = vscode.languages.registerCompletionItemProvider(autoCompleteOn, {
-    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
-      const range = document.getWordRangeAtPosition(position, /\S+/);
-      const currentLine = document.lineAt(position.line);
-      const isCssPropLine = currentLine.text.includes('css={{');
+  const completionProvider = vscode.languages.registerCompletionItemProvider(
+    autoCompleteOn,
+    {
+      provideCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token,
+        context
+      ) {
+        const range = document.getWordRangeAtPosition(position, /\S+/);
+        const currentLine = document.lineAt(position.line);
+        const isCssPropLine = currentLine.text.includes("css={{");
+        const isVarPresent = currentLine.text.includes("var(");
 
-      const variables = finalItems.map(({ name, value }) => getCompletionItem({
-        name,
-        value,
-        range,
-        isCssPropLine
-      }));
+        const variables = finalItems.map(({ name, value }) =>
+          getCompletionItem({
+            name,
+            value,
+            range,
+            isCssPropLine,
+            isVarPresent,
+          })
+        );
 
-      return variables;
+        return variables;
+      },
     }
-  });
+  );
 
   // Support go to definition
-  const definitionProvider = vscode.languages.registerDefinitionProvider(autoCompleteOn, {
-    async provideDefinition(document: vscode.TextDocument, position: vscode.Position) {
-      const variable = getVariableAtPosition(document, position);
+  const definitionProvider = vscode.languages.registerDefinitionProvider(
+    autoCompleteOn,
+    {
+      async provideDefinition(
+        document: vscode.TextDocument,
+        position: vscode.Position
+      ) {
+        const variable = getVariableAtPosition(document, position);
 
-      if (!variable) { return []; };
+        if (!variable) {
+          return [];
+        }
 
-      return finalItems
-        .filter(({ name }) => variable === name)
-        .map(({ name, uri, range }) => new vscode.Location(uri, range));
+        return finalItems
+          .filter(({ name }) => variable === name)
+          .map(({ name, uri, range }) => new vscode.Location(uri, range));
+      },
     }
-  });
+  );
 
   const hoverProvider = vscode.languages.registerHoverProvider(autoCompleteOn, {
-    async provideHover(document: vscode.TextDocument, position: vscode.Position) {
+    async provideHover(
+      document: vscode.TextDocument,
+      position: vscode.Position
+    ) {
       const variable = getVariableAtPosition(document, position);
 
-      if (!variable) { return null; };
+      if (!variable) {
+        return null;
+      }
 
       const variableItem = finalItems.find(({ name }) => name === variable);
 
-      if (!variableItem) { return null; };
+      if (!variableItem) {
+        return null;
+      }
 
       return new vscode.Hover(getHoverPreview(variableItem.value));
-    }
+    },
   });
 
   context.subscriptions.push(completionProvider);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
-import * as vscode from "vscode";
-import * as isColor from "is-color";
+import * as vscode from 'vscode';
+import * as isColor from 'is-color';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const DatauriParser = require("datauri/parser");
+const DatauriParser = require('datauri/parser');
 
 type ItemBase = {
   name: string;
@@ -63,7 +63,7 @@ export function getVariableAtPosition(
 
   const textAtPosition = document.getText(currentRange);
 
-  if (!textAtPosition.includes("var(--")) {
+  if (!textAtPosition.includes('var(--')) {
     return;
   }
 
@@ -97,6 +97,6 @@ export function getHoverPreview(value: string) {
   </svg>
   `;
 
-  datauri.format(".svg", src);
+  datauri.format('.svg', src);
   return `![](${datauri.content})`;
 }


### PR DESCRIPTION
Resolves #1 

Changes in this PR include:
1. Updating the autocomplete filter text so that it doesn't close out if you type "--"
2. Detecting if "var(" is already in the current line, and adjusting the autocomplete range and replacement text accordingly
3. A bunch of code formatting changes from the vscode formatter.