### PR TITLE
Add detection for variables defined in the same file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ const defaultConfig: Config = {
   ],
 };
 
-function extractVarsFromDocument(document) {
+function extractVarsFromDocument(document: vscode.TextDocument): Var[] {
   const file = document.getText();
   const vars = new Map();
   return file
@@ -58,7 +58,7 @@ function extractVarsFromDocument(document) {
         ),
       };
     })
-    .filter(Boolean);
+    .filter(Boolean) as Var[];
 }
 
 export async function activate(context: vscode.ExtensionContext) {


### PR DESCRIPTION
I've added some detection to scan the current document on completion/definition/hover and show up any CSS Vars that are defined in the same file. (Below is the same file split vertically as the two styled-components are quite far from each other)

![CleanShot 2022-04-21 at 18 48 14](https://user-images.githubusercontent.com/1085899/164428759-645caeae-aa52-407a-afd2-87f8b03ef9e7.png)

